### PR TITLE
Fix deadlock and crash

### DIFF
--- a/src/gridftp_hdfs.c
+++ b/src/gridftp_hdfs.c
@@ -96,17 +96,13 @@ GlobusExtensionDefineModule(globus_gridftp_server_hdfs) =
 void
 segv_handler (int sig)
 {
-  printf ("SEGV triggered in native code.\n");
+  write(1, "SEGV triggered in native code.\n", 31);
   const int max_trace = 32;
   void *trace[max_trace];
-  char **messages = (char **)NULL;
   int i, trace_size = 0;
 
   trace_size = backtrace(trace, max_trace);
-  messages = backtrace_symbols(trace, trace_size);
-  for (i=0; i<trace_size; ++i) {
-	printf("[bt] %s\n", messages[i]);
-  }
+  backtrace_symbols_fd(trace, trace_size, 1);
   raise (SIGQUIT);
   signal (SIGSEGV, SIG_DFL);
   raise (SIGSEGV);

--- a/src/gridftp_hdfs_cksm.c
+++ b/src/gridftp_hdfs_cksm.c
@@ -474,7 +474,10 @@ globus_result_t hdfs_get_checksum_internal(hdfs_handle_t *hdfs_handle, const cha
     }
 
     // Not used in this function except in the contents of the error message.
-    hdfs_handle->pathname = strdup(pathname);
+    int allocated_pathname;
+    if ((allocated_pathname = (hdfs_handle->pathname == NULL))) {
+        hdfs_handle->pathname = strdup(pathname);
+    }
 
     size_t cksm_len = strlen(hdfs_handle->cksm_root);
     size_t path_len = strlen(pathname);
@@ -599,8 +602,9 @@ globus_result_t hdfs_get_checksum_internal(hdfs_handle_t *hdfs_handle, const cha
         globus_gfs_log_message(GLOBUS_GFS_LOG_INFO, "Got checksum (%s:%s) for %s.\n", requested_cksm, *cksm_value, filename);
     }
 
-    if (hdfs_handle->pathname) {
+    if (allocated_pathname && hdfs_handle->pathname) {
         free(hdfs_handle->pathname);
+        hdfs_handle->pathname = NULL;
     }
     free(cksm);
     free(buffer);


### PR DESCRIPTION
- Fixes deadlock in the `SIGSEGV` handler by avoiding functions that can allocate memory.
- Fixes potential double-free that exists when the checksum needs to be regenerated from scratch.