### PR TITLE
[WIP] Remove /cksums entry when a file is deleted

### DIFF
--- a/src/gridftp_hdfs.c
+++ b/src/gridftp_hdfs.c
@@ -410,6 +410,8 @@ hdfs_command(
             }
         } else {
             result = GLOBUS_SUCCESS;
+	    // Delete associated checksums file
+	    hdfs_rm_checksums(hdfs_handle);
         }
 }
         break;

--- a/src/gridftp_hdfs.c
+++ b/src/gridftp_hdfs.c
@@ -410,8 +410,11 @@ hdfs_command(
             }
         } else {
             result = GLOBUS_SUCCESS;
-	    // Delete associated checksums file
-	    hdfs_rm_checksums(hdfs_handle);
+
+            // Delete associated checksums file
+            if (hdfs_handle->cksm_cleanup) {
+                hdfs_rm_checksums(hdfs_handle);
+            }
         }
 }
         break;
@@ -787,6 +790,20 @@ hdfs_start(
         hdfs_parse_checksum_types(hdfs_handle, checksums_char);
     } else {
         hdfs_handle->cksm_types = 0;
+    }
+
+    const char * checksums_cleanup = getenv("GRIDFTP_HDFS_CHECKSUMS_CLEANUP");
+    if (checksums_cleanup) {
+        if (strcasecmp(checksums_cleanup, "yes") == 0 || strcmp(checksums_cleanup, "1") == 0) {
+            hdfs_handle->cksm_cleanup = 1;
+        } else {
+            hdfs_handle->cksm_cleanup = 0;
+        }
+        globus_gfs_log_message(GLOBUS_GFS_LOG_INFO,
+            "Checksum cleanup: %s\n", hdfs_handle->cksm_cleanup ? "yes" : "no");
+    } else {
+        // Checksum cleanup defaults to off
+        hdfs_handle->cksm_cleanup = 0;
     }
 
     hdfs_handle->tmp_file_pattern = (char *)NULL;

--- a/src/gridftp_hdfs.h
+++ b/src/gridftp_hdfs.h
@@ -83,6 +83,7 @@ typedef struct globus_l_gfs_hdfs_handle_s
     char *                              expected_cksm;
     const char *                        cksm_root;
     unsigned char                       cksm_types;
+    unsigned int                        cksm_cleanup;
     MD5_CTX                             md5;
     char                                md5_output[MD5_DIGEST_LENGTH];
     char                                md5_output_human[MD5_DIGEST_LENGTH*2+1];

--- a/src/gridftp_hdfs.h
+++ b/src/gridftp_hdfs.h
@@ -221,5 +221,9 @@ hdfs_get_checksum(
     const char *       requested_cksm, 
     char **            cksm_value);
 
+int
+hdfs_rm_checksums(
+    hdfs_handle_t *    hdfs_handle);
+
 #pragma GCC visibility pop
 

--- a/src/gridftp_hdfs_cksm.c
+++ b/src/gridftp_hdfs_cksm.c
@@ -137,7 +137,7 @@ char *concatenate(char *buffer, globus_off_t *offset, globus_size_t *length, con
  */
 static char * hdfs_get_cksm_filename(hdfs_handle_t *hdfs_handle) {
 
-    if (!hdfs_handle->cksm_root) {
+    if (!hdfs_handle || !hdfs_handle->cksm_root || !hdfs_handle->pathname) {
         return NULL;
     }
 
@@ -426,7 +426,7 @@ globus_result_t hdfs_save_checksum(hdfs_handle_t *hdfs_handle) {
  */
 int hdfs_rm_checksums(hdfs_handle_t *hdfs_handle) {
 
-    if (!hdfs_handle->cksm_types || !hdfs_handle->cksm_root) {
+    if (!hdfs_handle || !hdfs_handle->cksm_types || !hdfs_handle->cksm_root) {
         return 0;
     }
 
@@ -447,7 +447,7 @@ int hdfs_rm_checksums(hdfs_handle_t *hdfs_handle) {
     if (rc == 0) {
         globus_gfs_log_message(GLOBUS_GFS_LOG_INFO, "Removed checksums %s.\n", filename);
     } else {
-        globus_gfs_log_message(GLOBUS_GFS_LOG_WARN, "Could not remove checksums %s.\n", filename);
+        globus_gfs_log_message(GLOBUS_GFS_LOG_WARN, "Failed to remove remove checksums %s: (errno %d, %s)\n", filename, errno, strerror(errno));
     }
 
     free(filename);


### PR DESCRIPTION
When a file is deleted with GridFTP, issue a delete for the matching /cksums file.

- The code to concatenate the checksum filename is refactored into a new function: hdfs_get_cksm_filename
- Free the malloc()ed memory from the checksum filename

It seems to work as intended from very light testing. I'd like to get an opinion from someone with more experience before further testing at our site. Could you point me in the right direction, @bbockelm or @djw8605 ?