### PR TITLE
New scheme for one-replica files

### DIFF
--- a/src/gridftp_hdfs_recv.c
+++ b/src/gridftp_hdfs_recv.c
@@ -235,7 +235,7 @@ hdfs_recv(
 {
     globus_l_gfs_hdfs_handle_t *        hdfs_handle;
     globus_result_t                     rc = GLOBUS_SUCCESS; 
-
+    struct hdfsStreamBuilder *          builder = NULL;
     GlobusGFSName(hdfs_recv);
 
 
@@ -277,7 +277,30 @@ hdfs_recv(
         goto cleanup;
     }
 
-    hdfs_handle->fd = hdfsOpenFile(hdfs_handle->fs, hdfs_handle->pathname, O_WRONLY, 0, num_replicas, 0);
+    builder = hdfsStreamBuilderAlloc(hdfs_handle->fs, hdfs_handle->pathname, O_WRONLY);
+    if (!builder) {
+        SystemError(hdfs_handle,
+                    "allocating a file handle due to an internal HDFS error.",
+                    rc);
+        goto cleanup;
+    }
+    if (hdfsStreamBuilderSetReplication(builder, num_replicas)) {
+        SystemError(hdfs_handle,
+                    "setting number of replicas on file handle.",
+                    rc);
+        goto cleanup;
+    }
+    // If we have only one replica, then we set the blocksize to an admittedly arbitrary 40GB.
+    // This way, any data losses resulting in blocks missing result in one bad file per block.
+    if (num_replicas == 1 && hdfsStreamBuilderSetDefaultBlockSize(builder, 42949672960)) {
+        SystemError(hdfs_handle,
+                    "setting block size to 40GB.",
+                    rc);
+        goto cleanup;
+    }
+
+    hdfs_handle->fd = hdfsStreamBuilderBuild(builder);
+    builder = NULL;
     if (!hdfs_handle->fd)
     {
         if (errno == EINTERNAL) {
@@ -300,6 +323,9 @@ hdfs_recv(
     hdfs_dispatch_write(hdfs_handle);
 
 cleanup:
+    if (builder) {
+        hdfsStreamBuilderFree(builder);
+    }
     if (rc != GLOBUS_SUCCESS) {
         set_done(hdfs_handle, rc);
         if (!hdfs_handle->sent_finish) {


### PR DESCRIPTION
This PR makes it a bit more pragmatic to keep certain files at one replica.

With this, the replica map can take globs as the pattern, such as:
```
/cms/store/mc/*/AODSIM/*.root 1
```

Further, if the replica count is set to 1, then we increase the blocksize to 40GB.  The number is somewhat arbitrary, but the intent is to ensure that the file is written as a single block in order to minimize losses when there is a disk loss.

@jthiltges 